### PR TITLE
feat(dockerfile): update to support multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.74.0 AS chef
+FROM clux/muslrust:1.77.2-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app
@@ -9,12 +9,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+RUN cargo chef cook --release --target "$(arch)-unknown-linux-musl" --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --target x86_64-unknown-linux-musl --bin rds_proxy
+RUN cargo build --release --target "$(arch)-unknown-linux-musl" --bin rds_proxy && \
+    mv "target/$(arch)-unknown-linux-musl/release/rds_proxy" /rds_proxy
 
 FROM alpine:3.18.5 AS runtime
 RUN addgroup -S rdsproxy && adduser -S rdsproxy -G rdsproxy
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rds_proxy /usr/local/bin/
+COPY --from=builder /rds_proxy /usr/local/bin/
 USER rdsproxy
 CMD ["/usr/local/bin/rds_proxy", "--config", "/etc/rds_proxy/config.json", "--listen", "0.0.0.0:5435"]


### PR DESCRIPTION
update clux/muslrust to a version which supports aarch64
use `arch` to get either `x86_64` or `aarch64`
move outputted binary to a generic location because docker's `COPY` command can't use `$(arch)`