### PR TITLE
fix: update to a more recent muslrust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.78-stable AS chef
+FROM clux/muslrust:1.78.0-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.78.0-stable AS chef
+FROM clux/muslrust:1.82.0-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.82.0-stable AS chef
+FROM clux/muslrust:1.81.0-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.77.2-stable AS chef
+FROM clux/muslrust:1.78-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.81.0-stable AS chef
+FROM clux/muslrust:1.79.0-stable AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /app


### PR DESCRIPTION
I ran into issues getting the docker container to build for me. 

Unfortunately, I didn't keep an output of the docker build error, but it was related to an out of date package dependency. Bumping the versioning resolved my issue, and I wanted to push my changes upstream to benefit everyone.